### PR TITLE
Default to 80 columns output if terminal size is unknown

### DIFF
--- a/ubuntu_bug_triage/triage.py
+++ b/ubuntu_bug_triage/triage.py
@@ -81,7 +81,7 @@ class TeamTriage(Triage):
     def current_backlog_count(self):
         """Get team's current backlog count."""
         return len(
-            self.launchpad.ubuntu.distributions['Ubuntu'].searchTasks(
+            self.launchpad.distributions['Ubuntu'].searchTasks(
                 bug_subscriber=self.team
             )
         )
@@ -89,7 +89,7 @@ class TeamTriage(Triage):
     def updated_bugs(self):
         """Print update bugs for a specific date or date range."""
         updated_tasks = (
-            self.launchpad.ubuntu.distributions['Ubuntu'].searchTasks(
+            self.launchpad.distributions['Ubuntu'].searchTasks(
                 modified_since=self.date,
                 structural_subscriber=self.team
             )
@@ -127,7 +127,7 @@ class PackageTriage(Triage):
 
         self._log.debug('finding bugs for package: %s', package)
         self.package = (
-            self.launchpad.ubuntu.distributions['Ubuntu'].getSourcePackage(
+            self.launchpad.distributions['Ubuntu'].getSourcePackage(
                 name=package
             )
         )

--- a/ubuntu_bug_triage/view.py
+++ b/ubuntu_bug_triage/view.py
@@ -88,8 +88,9 @@ class TerminalView(BaseView):
         super().__init__()
 
         try:
-            _, self.term_columns = os.popen('stty size 2>/dev/null', 'r').read().split()
-        except:
+            cmd = 'stty size 2>/dev/null'
+            _, self.term_columns = os.popen(cmd, 'r').read().split()
+        except OSError:
             # Fallback to a reasonable default if `stty size` fails, e.g. when
             # the script not called from a terminal.
             self.term_columns = 80

--- a/ubuntu_bug_triage/view.py
+++ b/ubuntu_bug_triage/view.py
@@ -87,7 +87,12 @@ class TerminalView(BaseView):
         """Initialize terminal view."""
         super().__init__()
 
-        _, self.term_columns = os.popen('stty size', 'r').read().split()
+        try:
+            _, self.term_columns = os.popen('stty size 2>/dev/null', 'r').read().split()
+        except:
+            # Fallback to a reasonable default if `stty size` fails, e.g. when
+            # the script not called from a terminal.
+            self.term_columns = 80
 
         # The table has a set number characters that always exist:
         #     4 for '|' boarders


### PR DESCRIPTION
* If the call to `stty size` fails assume an 80 columns width
 * Triage classes: fix call to launchpad.distributions