### PR TITLE
Restrict the search to bugs with a given status (--status flag)

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -6,3 +6,9 @@ jobs=4
 # R0903: Too few public methods (%s/%s)
 # C0103: Invalid name
 disable=R0903,C0103
+
+[DESIGN]
+
+# Maximum number of arguments for function / method.
+# R0913: Too many arguments (%s/%s) (too-many-arguments)
+max-args=6

--- a/ubuntu_bug_triage/__init__.py
+++ b/ubuntu_bug_triage/__init__.py
@@ -39,3 +39,12 @@ UBUNTU_PACKAGE_TEAMS = [
     'translators-packages',
     'snappy-dev',
 ]
+
+# By default show only bugs with any of the following statuses.
+ACTIONABLE_BUG_STATUSES = [
+    'New',
+    'Incomplete',
+    'Confirmed',
+    'Triaged',
+    'In Progress'
+]

--- a/ubuntu_bug_triage/__main__.py
+++ b/ubuntu_bug_triage/__main__.py
@@ -6,6 +6,7 @@ import logging
 import sys
 
 from . import UBUNTU_PACKAGE_TEAMS
+from . import ACTIONABLE_BUG_STATUSES
 from .triage import PackageTriage, TeamTriage
 from .view import BrowserView, CSVView, JSONView, TerminalView
 
@@ -47,6 +48,15 @@ def parse_args():
         '--include-project', '-p', action='store_true',
         help='include project bugs in output'
     )
+    parser.add_argument(
+        '--status', '-s', action='append', default=None, metavar='STATUS',
+        choices=["New", "Incomplete", "Opinion", "Invalid", "Won't Fix",
+                 "Expired", "Confirmed", "Triaged", "In Progress",
+                 "Fix Committed", "Fix Released", "Incomplete (with response)",
+                 "Incomplete (without response)"],
+        help='Restrict the search to bugs with the given status.'
+        ' Can be specified multiple times. Defaults: ' + ', '.join(
+            ACTIONABLE_BUG_STATUSES) + '.')
 
     return parser.parse_args()
 
@@ -63,6 +73,9 @@ def setup_logging(debug):
 def launch():
     """Launch ubuntu-bug-triage."""
     args = parse_args()
+    if args.status is None:
+        args.status = ACTIONABLE_BUG_STATUSES
+    args.status = list(set(args.status))
     setup_logging(args.debug)
 
     if args.package_or_team in UBUNTU_PACKAGE_TEAMS:
@@ -70,10 +83,11 @@ def launch():
             logging.getLogger(__name__).warning(
                 "N.B. --include-project has no effect when running against a"
                 " package team")
-        triage = TeamTriage(args.package_or_team, args.days, args.anon)
+        triage = TeamTriage(args.package_or_team, args.days,
+                            args.anon, args.status)
     else:
         triage = PackageTriage(args.package_or_team, args.days, args.anon,
-                               args.include_project)
+                               args.include_project, args.status)
 
     bugs = triage.updated_bugs()
     if args.csv:

--- a/ubuntu_bug_triage/__main__.py
+++ b/ubuntu_bug_triage/__main__.py
@@ -49,14 +49,15 @@ def parse_args():
         help='include project bugs in output'
     )
     parser.add_argument(
-        '--status', '-s', action='append', default=None, metavar='STATUS',
-        choices=["New", "Incomplete", "Opinion", "Invalid", "Won't Fix",
+        '--status', '-s', action='append', default=[], metavar='STATUS',
+        choices=["any", "New", "Incomplete", "Opinion", "Invalid", "Won't Fix",
                  "Expired", "Confirmed", "Triaged", "In Progress",
                  "Fix Committed", "Fix Released", "Incomplete (with response)",
                  "Incomplete (without response)"],
         help='Restrict the search to bugs with the given status.'
         ' Can be specified multiple times. Defaults: ' + ', '.join(
-            ACTIONABLE_BUG_STATUSES) + '.')
+            ACTIONABLE_BUG_STATUSES) + '.'
+    )
 
     return parser.parse_args()
 
@@ -73,8 +74,10 @@ def setup_logging(debug):
 def launch():
     """Launch ubuntu-bug-triage."""
     args = parse_args()
-    if args.status is None:
+    if not args.status:
         args.status = ACTIONABLE_BUG_STATUSES
+    elif 'any' in args.status:
+        args.status = []
     args.status = list(set(args.status))
     setup_logging(args.debug)
 


### PR DESCRIPTION
Allow the query to Launchpad to be restricted to bugs with a specified status. The implementation relies on the Launchpad API treating a query for bugs with an empty status as a query for which no status has been
specified, thus returning bugs with any status. This behavior is not  explicitly documented in the Launchpad API [0].
    
[0] https://launchpad.net/+apidoc/1.0.html
