### PR TITLE
Fix typo in ubuntu-security team name

### DIFF
--- a/ubuntu_bug_triage/__init__.py
+++ b/ubuntu_bug_triage/__init__.py
@@ -31,7 +31,7 @@ UBUNTU_PACKAGE_TEAMS = [
     'maas-maintainers',
     'ubuntu-server',
     'ubuntu-printing',
-    'ubuntu-security-bugs',
+    'ubuntu-security',
     'mir-team',
     'kernel-packages',
     'unsubscribed',


### PR DESCRIPTION
ubuntu-security-bugs does not exist in
https://people.canonical.com/~ubuntu-archive/package-team-mapping.json and
results in a runtime error when this is specified as the search parameter -
instead this should likely be just ubuntu-security.

```
$ ubuntu-bug-triage --debug ubuntu-security-bugs
logging into Launchpad
finding bugs for team: ubuntu-security-bugs
Traceback (most recent call last):
  File "/snap/ubuntu-bug-triage/115/lib/python3.5/site-packages/lazr/restfulclient/resource.py", line 998, in __getitem__
    shim_resource._ensure_representation()
  File "/snap/ubuntu-bug-triage/115/lib/python3.5/site-packages/lazr/restfulclient/resource.py", line 379, in _ensure_representation
    representation = self._root._browser.get(self._wadl_resource)
  File "/snap/ubuntu-bug-triage/115/lib/python3.5/site-packages/lazr/restfulclient/_browser.py", line 448, in get
    response, content = self._request(url, extra_headers=headers)
  File "/snap/ubuntu-bug-triage/115/lib/python3.5/site-packages/lazr/restfulclient/_browser.py", line 438, in _request
    raise error
lazr.restfulclient.errors.NotFound: HTTP Error 404: Not Found
Response headers:
---
-content-encoding: gzip
content-length: 103
content-type: text/plain
date: Mon, 25 Nov 2019 10:40:46 GMT
server: zope.server.http (HTTP)
status: 404
vary: Accept-Encoding
x-powered-by: Zope (www.zope.org), Python (www.python.org)
---
Response body:
---
b"Object: <lp.systemhomes.WebServiceApplication object at 0x7f468bc3f810>, name: u'~ubuntu-security-bugs'"
---

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/snap/ubuntu-bug-triage/115/bin/ubuntu-bug-triage", line 11, in <module>
    load_entry_point('ubuntu-bug-triage==19.1', 'console_scripts', 'ubuntu-bug-triage')()
  File "/snap/ubuntu-bug-triage/115/lib/python3.5/site-packages/ubuntu_bug_triage/__main__.py", line 90, in launch
    args.anon, args.status)
  File "/snap/ubuntu-bug-triage/115/lib/python3.5/site-packages/ubuntu_bug_triage/triage.py", line 78, in __init__
    self.team = self.launchpad.people[team]
  File "/snap/ubuntu-bug-triage/115/lib/python3.5/site-packages/lazr/restfulclient/resource.py", line 1001, in __getitem__
    raise KeyError(key)
KeyError: 'ubuntu-security-bugs'
```