### PR TITLE
Dont warn on package when looking for project.

### DIFF
--- a/ubuntu_bug_triage/triage.py
+++ b/ubuntu_bug_triage/triage.py
@@ -134,7 +134,7 @@ class PackageTriage(Triage):
             )
         )
 
-        if self.package is None:
+        if self.package is None and not include_project:
             self._log.warning('warn: no Ubuntu package with that name exists')
 
         self.project = None


### PR DESCRIPTION
When trying to query a project dont warn about no package being found.  This prevents piping results to something like jq for further data processing.  It also seems assumed that if passing in -p that a package would or may not exist.