### PR TITLE
implement an new 'ignore' option

### DIFF
--- a/ubuntu_bug_triage/__main__.py
+++ b/ubuntu_bug_triage/__main__.py
@@ -39,12 +39,12 @@ def parse_args():
     parser.add_argument(
         "--ignore-user",
         default=[],
-        nargs='*',
+        nargs="*",
         help="""ignore bugs edited last by the listed person""",
     )
     parser.add_argument("--json", action="store_true", help="output as JSON")
     parser.add_argument(
-        "--open", action="store_true", help="open resulting bugs in web browser",
+        "--open", action="store_true", help="open resulting bugs in web browser"
     )
     parser.add_argument(
         "--include-project",
@@ -108,8 +108,9 @@ def launch():
                 "N.B. --include-project has no effect when running against a"
                 " package team"
             )
-        triage = TeamTriage(args.package_or_team, args.days, args.anon, args.status,
-                            args.ignore_user)
+        triage = TeamTriage(
+            args.package_or_team, args.days, args.anon, args.status, args.ignore_user
+        )
     else:
         triage = PackageTriage(
             args.package_or_team,
@@ -117,7 +118,7 @@ def launch():
             args.anon,
             args.include_project,
             args.status,
-            args.ignore_user
+            args.ignore_user,
         )
 
     bugs = triage.updated_bugs()

--- a/ubuntu_bug_triage/__main__.py
+++ b/ubuntu_bug_triage/__main__.py
@@ -36,6 +36,12 @@ def parse_args():
     parser.add_argument(
         "--debug", action="store_true", help="additional logging output"
     )
+    parser.add_argument(
+        "--ignore-user",
+        default=[],
+        nargs='*',
+        help="""ignore bugs edited last by the listed person""",
+    )
     parser.add_argument("--json", action="store_true", help="output as JSON")
     parser.add_argument(
         "--open", action="store_true", help="open resulting bugs in web browser",
@@ -72,12 +78,6 @@ def parse_args():
         " Can be specified multiple times. Defaults: "
         + ", ".join(ACTIONABLE_BUG_STATUSES)
         + ".",
-    )
-    parser.add_argument(
-        "--ignore-user",
-        default=[],
-        nargs='*',
-        help="""ignore bugs edited last by the listed person""",
     )
 
     return parser.parse_args()

--- a/ubuntu_bug_triage/__main__.py
+++ b/ubuntu_bug_triage/__main__.py
@@ -108,7 +108,8 @@ def launch():
                 "N.B. --include-project has no effect when running against a"
                 " package team"
             )
-        triage = TeamTriage(args.package_or_team, args.days, args.anon, args.status, args.ignore_user)
+        triage = TeamTriage(args.package_or_team, args.days, args.anon, args.status,
+            args.ignore_user)
     else:
         triage = PackageTriage(
             args.package_or_team,

--- a/ubuntu_bug_triage/__main__.py
+++ b/ubuntu_bug_triage/__main__.py
@@ -75,6 +75,7 @@ def parse_args():
     )
     parser.add_argument(
         "--ignore-user",
+        default=[],
         nargs='*',
         help="""ignore bugs edited last by the listed person""",
     )
@@ -100,9 +101,6 @@ def launch():
         args.status = []
     args.status = list(set(args.status))
     setup_logging(args.debug)
-
-    if not args.ignore:
-        args.ignore = []
 
     if args.package_or_team in UBUNTU_PACKAGE_TEAMS:
         if args.include_project:

--- a/ubuntu_bug_triage/__main__.py
+++ b/ubuntu_bug_triage/__main__.py
@@ -73,6 +73,11 @@ def parse_args():
         + ", ".join(ACTIONABLE_BUG_STATUSES)
         + ".",
     )
+    parser.add_argument(
+        "--ignore",
+        nargs='*',
+        help="""ignore bugs edited last by the listed person""",
+    )
 
     return parser.parse_args()
 
@@ -96,13 +101,16 @@ def launch():
     args.status = list(set(args.status))
     setup_logging(args.debug)
 
+    if not args.ignore:
+        args.ignore = []
+
     if args.package_or_team in UBUNTU_PACKAGE_TEAMS:
         if args.include_project:
             logging.getLogger(__name__).warning(
                 "N.B. --include-project has no effect when running against a"
                 " package team"
             )
-        triage = TeamTriage(args.package_or_team, args.days, args.anon, args.status)
+        triage = TeamTriage(args.package_or_team, args.days, args.anon, args.status, args.ignore)
     else:
         triage = PackageTriage(
             args.package_or_team,
@@ -110,6 +118,7 @@ def launch():
             args.anon,
             args.include_project,
             args.status,
+            args.ignore
         )
 
     bugs = triage.updated_bugs()

--- a/ubuntu_bug_triage/__main__.py
+++ b/ubuntu_bug_triage/__main__.py
@@ -109,7 +109,7 @@ def launch():
                 " package team"
             )
         triage = TeamTriage(args.package_or_team, args.days, args.anon, args.status,
-            args.ignore_user)
+                            args.ignore_user)
     else:
         triage = PackageTriage(
             args.package_or_team,

--- a/ubuntu_bug_triage/__main__.py
+++ b/ubuntu_bug_triage/__main__.py
@@ -108,7 +108,7 @@ def launch():
                 "N.B. --include-project has no effect when running against a"
                 " package team"
             )
-        triage = TeamTriage(args.package_or_team, args.days, args.anon, args.status, args.ignore)
+        triage = TeamTriage(args.package_or_team, args.days, args.anon, args.status, args.ignore_user)
     else:
         triage = PackageTriage(
             args.package_or_team,
@@ -116,7 +116,7 @@ def launch():
             args.anon,
             args.include_project,
             args.status,
-            args.ignore
+            args.ignore_user
         )
 
     bugs = triage.updated_bugs()

--- a/ubuntu_bug_triage/__main__.py
+++ b/ubuntu_bug_triage/__main__.py
@@ -74,7 +74,7 @@ def parse_args():
         + ".",
     )
     parser.add_argument(
-        "--ignore",
+        "--ignore-user",
         nargs='*',
         help="""ignore bugs edited last by the listed person""",
     )

--- a/ubuntu_bug_triage/bug.py
+++ b/ubuntu_bug_triage/bug.py
@@ -47,15 +47,15 @@ class Bug:
             self.tasks.append(BugTask(task))
 
         if not ignore_user:
-            self.last_active_user = ''
+            self.last_active_user = ""
         else:
             for comment in self._lp.messages:
                 datecreated = comment.date_created
-                commenter = comment.owner_link.split('~')[1]
+                commenter = comment.owner_link.split("~")[1]
 
             for active in self._lp.activity:
                 datechanged = active.datechanged
-                person = active.person_link.split('~')[1]
+                person = active.person_link.split("~")[1]
 
             if datecreated > datechanged:
                 self.last_active_user = commenter

--- a/ubuntu_bug_triage/bug.py
+++ b/ubuntu_bug_triage/bug.py
@@ -34,7 +34,7 @@ class BugTask:
 class Bug:
     """Bug class."""
 
-    def __init__(self, lp_link, ignore_user):
+    def __init__(self, lp_link, ignore_user = []):
         """Initialize bug class."""
         self._lp = lp_link
 

--- a/ubuntu_bug_triage/bug.py
+++ b/ubuntu_bug_triage/bug.py
@@ -34,7 +34,7 @@ class BugTask:
 class Bug:
     """Bug class."""
 
-    def __init__(self, lp_link, ignore_user = []):
+    def __init__(self, lp_link, ignore_user=[]):
         """Initialize bug class."""
         self._lp = lp_link
 

--- a/ubuntu_bug_triage/bug.py
+++ b/ubuntu_bug_triage/bug.py
@@ -34,7 +34,7 @@ class BugTask:
 class Bug:
     """Bug class."""
 
-    def __init__(self, lp_link):
+    def __init__(self, lp_link, ignore_user):
         """Initialize bug class."""
         self._lp = lp_link
 
@@ -42,21 +42,25 @@ class Bug:
         self.title = self._lp.title
 
         self.tasks = []
+
         for task in self._lp.bug_tasks:
             self.tasks.append(BugTask(task))
 
-        for comment in self._lp.messages:
-            datecreated = comment.date_created
-            commenter = comment.owner_link.split('~')[1]
-
-        for active in self._lp.activity:
-            datechanged = active.datechanged
-            person = active.person_link.split('~')[1]
-
-        if datecreated > datechanged:
-            self.last_active_user = commenter
+        if not ignore_user:
+            self.last_active_user = ''
         else:
-            self.last_active_user = person
+            for comment in self._lp.messages:
+                datecreated = comment.date_created
+                commenter = comment.owner_link.split('~')[1]
+
+            for active in self._lp.activity:
+                datechanged = active.datechanged
+                person = active.person_link.split('~')[1]
+
+            if datecreated > datechanged:
+                self.last_active_user = commenter
+            else:
+                self.last_active_user = person
 
     def __eq__(self, other):
         """Two bugs are identical if their ids are equal."""

--- a/ubuntu_bug_triage/bug.py
+++ b/ubuntu_bug_triage/bug.py
@@ -45,6 +45,19 @@ class Bug:
         for task in self._lp.bug_tasks:
             self.tasks.append(BugTask(task))
 
+        for comment in self._lp.messages:
+            datecreated = comment.date_created
+            commenter = comment.owner_link.split('~')[1]
+
+        for active in self._lp.activity:
+            datechanged = active.datechanged
+            person = active.person_link.split('~')[1]
+
+        if datecreated > datechanged:
+            self.last_active_user = commenter
+        else:
+            self.last_active_user = person
+
     def __eq__(self, other):
         """Two bugs are identical if their ids are equal."""
         return self.id == other.id

--- a/ubuntu_bug_triage/triage.py
+++ b/ubuntu_bug_triage/triage.py
@@ -97,7 +97,7 @@ class TeamTriage(Triage):
 
         bugs = []
         for bug_id in sorted(self._tasks_to_bug_ids(updated_tasks)):
-            bug = Bug(self.launchpad.bugs[bug_id])
+            bug = Bug(self.launchpad.bugs[bug_id], self.ignore_user)
 
             if self.team.name in BLACKLIST:
                 if self._all_src_on_blacklist(bug.tasks, self.team.name):
@@ -172,7 +172,7 @@ class PackageTriage(Triage):
 
         bugs = []
         for bug_id in sorted(self._tasks_to_bug_ids(updated_tasks)):
-            bug = Bug(self.launchpad.bugs[bug_id])
+            bug = Bug(self.launchpad.bugs[bug_id], self.ignore_user)
             if bug.last_active_user not in self.ignore_user:
                 bugs.append(bug)
 

--- a/ubuntu_bug_triage/triage.py
+++ b/ubuntu_bug_triage/triage.py
@@ -70,14 +70,14 @@ class Triage:
 class TeamTriage(Triage):
     """Triage Launchpad bugs for a particular Ubuntu team."""
 
-    def __init__(self, team, days, anon, status, ignore):
+    def __init__(self, team, days, anon, status, ignore_user):
         """Initialize Team Triage."""
         super().__init__(days, anon)
 
         self._log.debug("finding bugs for team: %s", team)
         self.team = self.launchpad.people[team]
         self.status = status
-        self.ignore = ignore
+        self.ignore_user = ignore_user
 
     def current_backlog_count(self):
         """Get team's current backlog count."""
@@ -99,20 +99,12 @@ class TeamTriage(Triage):
         for bug_id in sorted(self._tasks_to_bug_ids(updated_tasks)):
             bug = Bug(self.launchpad.bugs[bug_id])
 
-            lpbug = self.launchpad.bugs[bug_id]
-            commenter = None
-            for comment in lpbug.messages:
-                commenter = comment.owner_link.split('~')[1]
-            person = None
-            for active in lpbug.activity:
-                person = active.person_link.split('~')[1]
-
             if self.team.name in BLACKLIST:
                 if self._all_src_on_blacklist(bug.tasks, self.team.name):
                     self._log.debug("skipping bug: %s", bug_id)
                     continue
 
-            if commenter not in self.ignore and person not in self.ignore:
+            if bug.last_active_user not in self.ignore_user:
                 bugs.append(bug)
 
         return bugs
@@ -130,7 +122,7 @@ class TeamTriage(Triage):
 class PackageTriage(Triage):
     """Triage Launchpad bugs for a particular package."""
 
-    def __init__(self, package, days, anon, include_project, status, ignore):
+    def __init__(self, package, days, anon, include_project, status, ignore_user):
         """Initialize package triage."""
         super().__init__(days, anon)
 
@@ -138,7 +130,7 @@ class PackageTriage(Triage):
         self.package = self.launchpad.distributions["Ubuntu"].getSourcePackage(
             name=package
         )
-        self.ignore = ignore
+        self.ignore_user = ignore_user
 
         if self.package is None and not include_project:
             self._log.warning("warn: no Ubuntu package with that name exists")
@@ -180,15 +172,8 @@ class PackageTriage(Triage):
 
         bugs = []
         for bug_id in sorted(self._tasks_to_bug_ids(updated_tasks)):
-            bug = self.launchpad.bugs[bug_id]
-
-            commenter = None
-            for comment in bug.messages:
-                commenter = comment.owner_link.split('~')[1]
-            person = None
-            for active in bug.activity:
-                person = active.person_link.split('~')[1]
-            if commenter not in self.ignore and person not in self.ignore:
-                bugs.append(Bug(bug))
+            bug = Bug(self.launchpad.bugs[bug_id])
+            if bug.last_active_user not in self.ignore_user:
+                bugs.append(bug)
 
         return bugs


### PR DESCRIPTION
let filter out the bugs edited by the persons listed, it's useful for
example to filter out the bugs you triaged already

The code is working but could at least use some comments and better naming and descriptions but it should be enough to discuss if the option sounds interesting.

The motivation was to be able to filter out activity from known and trusted triaged or bugs already edited by yourself in the same day