### PR TITLE
CLI: Add --urls to print only URLs

### DIFF
--- a/ubuntu_bug_triage/__main__.py
+++ b/ubuntu_bug_triage/__main__.py
@@ -79,6 +79,9 @@ def parse_args():
         + ", ".join(ACTIONABLE_BUG_STATUSES)
         + ".",
     )
+    parser.add_argument(
+        "--urls", action="store_true", help="print only the urls of bugs to triage"
+    )
 
     return parser.parse_args()
 
@@ -122,7 +125,10 @@ def launch():
         )
 
     bugs = triage.updated_bugs()
-    if args.csv:
+    if args.urls:
+        for bug in bugs:
+            print(bug.url)
+    elif args.csv:
         CSVView(bugs)
     elif args.json:
         JSONView(bugs)


### PR DESCRIPTION
The current system of launching a browser with a long list of bugs is a
poor experience. As proposed, this adds the --urls option which will
only print the urls of the bugs to triage. Then a user can pass that
output (e.g `--urls | xargs webbrowser`) and avoid the issue.

Fixes #16