### PR TITLE
snap: build using core22

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,7 +9,7 @@ description: |
     output, or set the behavior to open the bugs in a browser and
     immediately begin bug triage.
 
-base: core20
+base: core22
 grade: stable
 confinement: strict
 adopt-info: ubuntu-bug-triage


### PR DESCRIPTION
Other than a generic "bump baseline" change, hopefully this will fix an
issue when querying LP for bugs in non-anonymous mode (works locally):

```
$ ubuntu-bug-triage -s New --include-project cloud-init 1
Traceback (most recent call last):
  File "/snap/ubuntu-bug-triage/225/bin/ubuntu-bug-triage", line 8, in <module>
    sys.exit(launch())
  File "/snap/ubuntu-bug-triage/225/lib/python3.8/site-packages/ubuntu_bug_triage/__main__.py", line 140, in launch
    triage = PackageTriage(
  File "/snap/ubuntu-bug-triage/225/lib/python3.8/site-packages/ubuntu_bug_triage/triage.py", line 126, in __init__
    super().__init__(date, anon)
  File "/snap/ubuntu-bug-triage/225/lib/python3.8/site-packages/ubuntu_bug_triage/triage.py", line 22, in __init__
    self.launchpad = self._launchpad_connect(anon)
  File "/snap/ubuntu-bug-triage/225/lib/python3.8/site-packages/ubuntu_bug_triage/triage.py", line 50, in _launchpad_connect
    return Launchpad.login_with(
  File "/snap/ubuntu-bug-triage/225/lib/python3.8/site-packages/launchpadlib/launchpad.py", line 564, in login_with
    return cls._authorize_token_and_login(
  File "/snap/ubuntu-bug-triage/225/lib/python3.8/site-packages/launchpadlib/launchpad.py", line 375, in _authorize_token_and_login
    credentials = authorization_engine(credentials, credential_store)
  File "/snap/ubuntu-bug-triage/225/lib/python3.8/site-packages/launchpadlib/credentials.py", line 598, in __call__
    request_token_string = self.get_request_token(credentials)
  File "/snap/ubuntu-bug-triage/225/lib/python3.8/site-packages/launchpadlib/credentials.py", line 613, in get_request_token
    authorization_json = credentials.get_request_token(
  File "/snap/ubuntu-bug-triage/225/lib/python3.8/site-packages/launchpadlib/credentials.py", line 192, in get_request_token
    response, content = _http_post(url, headers, params)
  File "/snap/ubuntu-bug-triage/225/lib/python3.8/site-packages/launchpadlib/credentials.py", line 110, in _http_post
    response, content = httplib2.Http(
  File "/snap/ubuntu-bug-triage/225/lib/python3.8/site-packages/httplib2/__init__.py", line 1708, in request
    (response, content) = self._request(
  File "/snap/ubuntu-bug-triage/225/lib/python3.8/site-packages/httplib2/__init__.py", line 1424, in _request
    (response, content) = self._conn_request(conn, request_uri, method, body, headers)
  File "/snap/ubuntu-bug-triage/225/lib/python3.8/site-packages/httplib2/__init__.py", line 1346, in _conn_request
    conn.connect()
  File "/snap/ubuntu-bug-triage/225/lib/python3.8/site-packages/httplib2/__init__.py", line 1138, in connect
    self.sock = self._context.wrap_socket(sock, server_hostname=self.host)
  File "/usr/lib/python3.8/ssl.py", line 500, in wrap_socket
    return self.sslsocket_class._create(
  File "/usr/lib/python3.8/ssl.py", line 1040, in _create
    self.do_handshake()
  File "/usr/lib/python3.8/ssl.py", line 1309, in do_handshake
    self._sslobj.do_handshake()
ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1131)
```

happening with vesion 2021.03.30+git521df57 (revision 225).
