### PR TITLE
fix: Make ignore user not greedy

### DIFF
--- a/ubuntu_bug_triage/__main__.py
+++ b/ubuntu_bug_triage/__main__.py
@@ -41,7 +41,7 @@ def parse_args():
     parser.add_argument(
         "--ignore-user",
         default=[],
-        nargs="*",
+        action="append",
         help="""ignore bugs edited last by the listed person""",
     )
     parser.add_argument("--json", action="store_true", help="output as JSON")


### PR DESCRIPTION
This changes the usage of --ignore-user to not be greedy. This prevents issues when specifying a package or team as well. The consequence is that a user will need to specify the ignore user flag multiple times if they need to specify multiple users to ignore.

fixes: #22