### PR TITLE
feat: enable filtering bugs by tags

### DIFF
--- a/ubuntu_bug_triage/__main__.py
+++ b/ubuntu_bug_triage/__main__.py
@@ -12,7 +12,7 @@ from .triage import PackageTriage, TeamTriage
 from .view import BrowserView, CSVView, JSONView, TerminalView
 
 
-def parse_args():
+def parse_args(args=None):
     """Set up command-line arguments."""
     parser = argparse.ArgumentParser("ubuntu-bug-triage")
     parser.add_argument(
@@ -89,8 +89,27 @@ def parse_args():
     parser.add_argument(
         "--urls", action="store_true", help="print only the urls of bugs to triage"
     )
+    parser.add_argument(
+        "--tag",
+        "-t",
+        action="append",
+        dest="tags",
+        default=[],
+        metavar="TAG",
+        help="Restrict the search to bugs with the given tags."
+        + " Can be specified multiple times. Prefixing the tag with a '-' to"
+        + " query bugs without the tag. E.g. --tag=this --tag=-notthat",
+    )
+    parser.add_argument(
+        "--any-tag",
+        dest="tags_combinator",
+        action="store_const",
+        const="Any",
+        default="All",
+        help="Set to return bugs matching 'Any' instead of 'All' tags.",
+    )
 
-    return parser.parse_args()
+    return parser.parse_args(args=args)
 
 
 def parse_date(args):
@@ -134,7 +153,13 @@ def launch():
                 " package team"
             )
         triage = TeamTriage(
-            args.package_or_team, date, args.anon, args.status, args.ignore_user
+            args.package_or_team,
+            date,
+            args.anon,
+            args.status,
+            args.ignore_user,
+            args.tags,
+            args.tags_combinator,
         )
     else:
         triage = PackageTriage(
@@ -144,6 +169,8 @@ def launch():
             args.include_project,
             args.status,
             args.ignore_user,
+            args.tags,
+            args.tags_combinator,
         )
 
     bugs = triage.updated_bugs()

--- a/ubuntu_bug_triage/test_main.py
+++ b/ubuntu_bug_triage/test_main.py
@@ -1,0 +1,27 @@
+import unittest
+
+from ubuntu_bug_triage import __main__ as ubt_main
+
+
+class CliTest(unittest.TestCase):
+    def test_tag_default(self):
+        args = ubt_main.parse_args(args=[])
+        assert args.tags == []
+        assert args.tags_combinator == "All"
+
+    def test_tags_parse(self):
+        """CLI parses negative and normal tags."""
+        mock_argv = [
+            "--any-tag",
+            "-t",
+            "foo",
+            "-tbar",
+            "--tag",
+            "baz",
+            "-t-notfoo",
+            "-t=-notbar",
+            "--tag=-notbaz",
+        ]
+        args = ubt_main.parse_args(args=mock_argv)
+        assert args.tags == ["foo", "bar", "baz", "-notfoo", "-notbar", "-notbaz"]
+        assert args.tags_combinator == "Any"


### PR DESCRIPTION
Update argument parser with --any-tag to switch tag combinator.
Add a --tag argument which can search by tag: `-tfoo -tbar`,
and which can do negative search: `--tag=-notfoo -t-notbar`.

The dash prefix is a bit fiddly with argparse's parser, so I left an example in the cli usage and a unittest in case the parser changes.